### PR TITLE
Update qald-7-train-en-wikidata.json

### DIFF
--- a/7/data/qald-7-train-en-wikidata.json
+++ b/7/data/qald-7-train-en-wikidata.json
@@ -240,7 +240,7 @@
       "answers": [
         {
           "head": {},
-          "boolean": false
+          "boolean": true
         }
       ]
     },


### PR DESCRIPTION
Error in the dataset for the question 7 "Was the wife of president Lincoln called Mary?".