### PR TITLE
Fixes mistranslation of GMT (board game company) into Greenwich Mean Time

### DIFF
--- a/9/data/qald-9-train-multilingual.json
+++ b/9/data/qald-9-train-multilingual.json
@@ -10,8 +10,8 @@
     "hybrid" : false,
     "question" : [ {
       "language" : "de",
-      "string" : "Liste alle Brettspiele durch MITTLERE GREENWICH-ZEIT. ",
-      "keywords" : "Brettspiel ,  mittlere Greenwich-Zeit "
+      "string" : "Liste alle Brettspiele von GMT. ",
+      "keywords" : "Brettspiel ,  GMT"
     }, {
       "language" : "ru",
       "string" : "Список все настольные игры от ВРЕМЯ ПО ГРИНВИЧУ. ",


### PR DESCRIPTION
I saw and fixed the German translation of the query "List all board games by GMT."