### PR TITLE
QALD-9 Test Multilingual 

### DIFF
--- a/9/data/qald-9-test-multilingual.json
+++ b/9/data/qald-9-test-multilingual.json
@@ -6410,7 +6410,14 @@
       "head" : {
         "vars" : [ "date" ]
       },
-      "results" : { }
+      "results" : {
+        "bindings" : [ {
+          "date" : {
+            "type" : "literal",
+            "value" : "2001-07-20"
+          }
+        } ]
+      }
     } ]
   }, {
     "id" : "123",


### PR DESCRIPTION
Answer should either have empty head and empty result... 

`"answers" : [ {
      "head" : { },
      "results" : { }
    } ]`

...or head with result...

`          "answers" : [ {
      "head" : {
        "vars" : [ "date" ]
      },
      "results" : {
        "bindings" : [ {
          "date" : {
            "type" : "literal",
            "value" : "2001-07-20"
          }
        } ]
      }
    }]`